### PR TITLE
Fix heroku issue #5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0',          group: :doc
 
+gem 'thin'
+
 # Use bootstrap
 gem 'bootstrap-sass', '~> 3.2.0'
 gem 'autoprefixer-rails'
@@ -51,4 +53,4 @@ gem 'rails_12factor', group: :production
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin]
-ruby "2.1.5"
+# ruby "2.1.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,7 @@ GEM
     autoprefixer-rails (5.2.1)
       execjs
       json
+    bcrypt (3.1.10)
     bcrypt (3.1.10-x86-mingw32)
     bootstrap-sass (3.2.0.2)
       sass (~> 3.2)
@@ -42,7 +43,9 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1.1)
+    daemons (1.2.2)
     erubis (2.7.0)
+    eventmachine (1.0.7)
     execjs (2.5.2)
     hike (1.2.3)
     i18n (0.7.0)
@@ -59,6 +62,7 @@ GEM
     mime-types (2.6.1)
     minitest (5.7.0)
     multi_json (1.11.1)
+    pg (0.18.2)
     pg (0.18.2-x86-mingw32)
     rack (1.5.5)
     rack-test (0.6.3)
@@ -104,7 +108,12 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    sqlite3 (1.3.10)
     sqlite3 (1.3.10-x86-mingw32)
+    thin (1.6.3)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0)
+      rack (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -123,6 +132,7 @@ GEM
       json (>= 1.8.0)
 
 PLATFORMS
+  ruby
   x86-mingw32
 
 DEPENDENCIES
@@ -138,10 +148,8 @@ DEPENDENCIES
   sass-rails (~> 4.0.3)
   sdoc (~> 0.4.0)
   sqlite3
+  thin
   turbolinks
   twilio-ruby
   tzinfo-data
   uglifier (>= 1.3.0)
-
-BUNDLED WITH
-   1.10.4


### PR DESCRIPTION
Fixed 

Error: 

```
2015-06-24T17:21:46.852742+00:00 heroku[web.1]: Starting process with command `bundle exec thin start -p 15533`
2015-06-24T17:21:48.505807+00:00 app[web.1]: bundler: command not found: thin
2015-06-24T17:21:48.505834+00:00 app[web.1]: Install missing gem executables with `bundle install`
2015-06-24T17:21:49.218072+00:00 heroku[web.1]: Process exited with status 127
2015-06-24T17:21:49.227806+00:00 heroku[web.1]: State changed from starting to crashed
2015-06-24T17:21:49.253127+00:00 heroku[web.1]: State changed from crashed to starting
2015-06-24T17:21:51.936552+00:00 heroku[web.1]: Starting process with command `bundle exec thin start -p 4334`
2015-06-24T17:21:53.712213+00:00 app[web.1]: Install missing gem executables with `bundle install`
2015-06-24T17:21:53.712075+00:00 app[web.1]: bundler: command not found: thin
2015-06-24T17:21:54.408324+00:00 heroku[web.1]: State changed from starting to crashed
2015-06-24T17:21:54.390112+00:00 heroku[web.1]: Process exited with status 127
```

This means that you have to install `thin` and run `bundle install` before deploying to Heroku.
